### PR TITLE
ESLint 8.0 fix

### DIFF
--- a/lib/rules/assign-timer-id.js
+++ b/lib/rules/assign-timer-id.js
@@ -10,6 +10,7 @@
 
 module.exports = {
   meta: {
+    hasSuggestions: true,
     messages: {
       assignTimerId:
         'timer id should assign to an identifier or member for cleaning up, `let timer = {{calleeName}}(...);`'


### PR DESCRIPTION
ESLint > 8.0 requires `meta.hasSuggestions`  set to `true` for the rule to be able to suggest.